### PR TITLE
Update link color and weight

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -111,7 +111,8 @@ input, select, textarea {
 		-ms-transition: color 0.2s ease-in-out, border-color 0.2s ease-in-out;
 		transition: color 0.2s ease-in-out, border-color 0.2s ease-in-out;
 		border-bottom: solid 1px #e4e4e4;
-		color: inherit;
+		color: #6fa8dc;
+		font-weight: 600;
 		text-decoration: none;
 	}
 

--- a/index.html
+++ b/index.html
@@ -129,9 +129,9 @@
                                 knowledge assembly to correct errors, find and resolve redundancies, infer missing
                                 information, filter to a scope of interest and assess belief.
                                 <br/>
-                                <b><a href="https://github.com/sorgerlab/indra">Code</a></b>
-                                &nbsp; <b><a href="https://indra.readthedocs.io">Docs</a></b> &nbsp;
-                                <b><a href="http://api.indra.bio:8000">REST API</a></b></p>
+                                <a href="https://github.com/sorgerlab/indra">Code</a>
+                                &nbsp; <a href="https://indra.readthedocs.io">Docs</a> &nbsp;
+                                <a href="http://api.indra.bio:8000">REST API</a></p>
                         </div>
                     </article>
                     <article>
@@ -146,9 +146,9 @@
                                 the effect of new knowledge on these results. It then notifies users
                                 about relevant new analysis results.
                                 <br/>
-                                <b><a href="https://emmaa.indra.bio">Website</a></b> &nbsp;
-                                <b><a href="https://github.com/indralab/emmaa">Code</a></b>
-                                &nbsp; <b><a href="https://emmaa.readthedocs.io">Docs</a></b> &nbsp;
+                                <a href="https://emmaa.indra.bio">Website</a> &nbsp;
+                                <a href="https://github.com/indralab/emmaa">Code</a>
+                                &nbsp; <a href="https://emmaa.readthedocs.io">Docs</a> &nbsp;
                         </div>
                     </article>
                     <article>
@@ -164,8 +164,8 @@
                             an integrated human-machine dialogue system to sequentially
                             explore the knowledge graph.
                                 <br/>
-                                <b><a href="https://discovery.indra.bio">Website</a></b> &nbsp;
-                                <b><a href="https://github.com/bgyori/indra_cogex">Code</a></b>
+                                <a href="https://discovery.indra.bio">Website</a> &nbsp;
+                                <a href="https://github.com/bgyori/indra_cogex">Code</a>
                         </div>
                     </article>
                     <article>
@@ -179,11 +179,11 @@
                                 and
                                 other concepts of interest, and returns a ranked list of relevant interactions.
                                 <br/>
-                                <a href="https://db.indra.bio"><b>Website</b></a>&nbsp;
-                                <a href="https://github.com/indralab/indra_db/blob/master/indra_db_service/README.md"><b>REST
-                                    API</b></a>
+                                <a href="https://db.indra.bio">Website</a>&nbsp;
+                                <a href="https://github.com/indralab/indra_db/blob/master/indra_db_service/README.md">
+                                    REST API</a>
                                 &nbsp;
-                                <a href="https://github.com/indralab/indra_db"><b>Code</b></a>
+                                <a href="https://github.com/indralab/indra_db">Code</a>
                             </p>
                         </div>
                     </article>
@@ -197,9 +197,9 @@
                                 assemble and lay out a pathway map. The pathway can be exported into various formats
                                 like SBML, SBGN, Kappa and others.
                                 <br/>
-                                <a href="http://pathwaymap.indra.bio"><b>Website</b></a>
+                                <a href="http://pathwaymap.indra.bio">Website</a>
                                 &nbsp;
-                                <a href="https://github.com/sorgerlab/indra_pathway_map"><b>Code</b></a>
+                                <a href="https://github.com/sorgerlab/indra_pathway_map">Code</a>
                             </p>
                         </div>
                     </article>
@@ -214,7 +214,7 @@
                                 described in the literature and databases. You can also build up a model of a mechanism
                                 during the dialogue, and then ask questions about the properties of the model to see if
                                 it behaves as expected.
-                                <br/><a href="http://dialogue.bio"><b>Website</b></a>
+                                <br/><a href="http://dialogue.bio">Website</a>
                             </p>
                         </div>
                     </article>
@@ -233,7 +233,7 @@
                                 models of mechanisms. Please contact us if you'd like
                                 to deploy CLARE on your Slack workspace.
                                 <br/>
-                                <a href="https://www.youtube.com/watch?v=hZRY6G2cwEU"><b>Demo video</b></a>
+                                <a href="https://www.youtube.com/watch?v=hZRY6G2cwEU">Demo video</a>
                         </div>
                     </article>
                     <article>
@@ -248,9 +248,9 @@
                                 a large collaboration funded by DARPA and the Gates Foundation to develop
                                 AI-driven decision support tools for Ethiopia.
                                 <br/>
-                                <a href="https://github.com/indralab/indra_world"><b>Code</b></a>
+                                <a href="https://github.com/indralab/indra_world">Code</a>
                                 &nbsp;
-                                <a href="https://www.dsmt-e.com"><b>DSMT-E</b></a>
+                                <a href="https://www.dsmt-e.com">DSMT-E</a>
                             </p>
                         </div>
                     </article>
@@ -267,9 +267,9 @@
                                 constructing explanations for correlations between genes involved in CRISPR screens of
                                 cancer cell lines found at <a href="http://depmap.org">depmap.org</a>.
                                 <br/>
-                                <a href="http://depmap.indra.bio"><b>DepMap explainer</b></a>
+                                <a href="http://depmap.indra.bio">DepMap explainer</a>
                                 &nbsp;
-                                <a href="https://network.indra.bio"><b>Network search</b></a>
+                                <a href="https://network.indra.bio">Network search</a>
                             </p>
                         </div>
                     </article>
@@ -283,7 +283,7 @@
                                 SARS-CoV-2 infects cells and the subsequent host
                                 response process, with the goal of finding new therapeutics using INDRA.
                                 <br/>
-                                <a href="https://covid19.indra.bio/"><b>Website</b></a>
+                                <a href="https://covid19.indra.bio/">Website</a>
                             </p>
                         </div>
                     </article>
@@ -296,7 +296,7 @@
                                 is working on understanding the regulation of pain and inflammation with the goal of
                                 finding new therapeutics using INDRA.
                                 <br/>
-                                <a href="https://panacea.indra.bio/"><b>Website</b></a>
+                                <a href="https://panacea.indra.bio/">Website</a>
                             </p>
                         </div>
                     </article>
@@ -312,7 +312,7 @@
                                 pretrained disambiguation models are publicly available through
                                 the Python package.
                                 <br/>
-                                <a href="https://github.com/indralab/adeft"><b>Code</b></a>
+                                <a href="https://github.com/indralab/adeft">Code</a>
                             </p>
                         </div>
                     </article>
@@ -327,9 +327,9 @@
                                 to choose between different senses of ambiguous synonyms. It can be integrated into
                                 applications as a Python package or through the REST service.
                                 <br/>
-                                <a href="http://grounding.indra.bio/"><b>Website and REST API</b></a>
+                                <a href="http://grounding.indra.bio/">Website and REST API</a>
                                 &nbsp;
-                                <a href="https://github.com/indralab/gilda"><b>Code</b></a>
+                                <a href="https://github.com/indralab/gilda">Code</a>
                             </p>
                         </div>
                     </article>
@@ -352,8 +352,8 @@
                                 PyOBO (a software package to facilitate processing
                                 biomedical ontologies in a unified fashion).
                                 <br/>
-                                <a href="https://biopragmatics.github.io/"><b>Website</b></a>
-                                <a href="https://github.com/biopragmatics/"><b>Code</b></a>
+                                <a href="https://biopragmatics.github.io/">Website</a>
+                                <a href="https://github.com/biopragmatics/">Code</a>
                             </p>
                         </div>
                     </article>
@@ -510,9 +510,9 @@
 
                 <p>
                     <span class="badge badge-published">Published</span>
-                    Gyori BM, Bachman JA, Subramanian K, Muhlich JL, Galescu L, Sorger PK. <strong><a
+                    Gyori BM, Bachman JA, Subramanian K, Muhlich JL, Galescu L, Sorger PK. <a
                         href="http://msb.embopress.org/content/13/11/954">From word models to executable models of
-                    signaling networks using automated assembly</a></strong>.
+                    signaling networks using automated assembly</a>.
                     <i>Molecular Systems Biology</i>, 2017 13(11):954.
                     <br/>Summary video: <a href="https://vimeo.com/265004298">https://vimeo.com/265004298</a></p>
 
@@ -522,8 +522,8 @@
                     <span class="badge badge-published">Published</span>
                     Gyori BM, Hoyt CT, Steppi A,
                     <a href='https://doi.org/10.1093/bioadv/vbac034'>
-                        <strong>Gilda: biomedical entity text normalization with machine-learned disambiguation as a
-                            service</strong>
+                        Gilda: biomedical entity text normalization with machine-learned disambiguation as a
+                            service
                     </a>
                     <i>Bioinformatics Advances</i>, 2022.
                 </p>
@@ -533,22 +533,19 @@
                     Scholten B, Guerrero Simón L, Krishnan S,
                     Vermeulen R, Pronk A, <strong>Gyori BM</strong>,
                     <strong>Bachman JA</strong>, Vlaanderen J, Stierum R.
-                    <strong><a href="https://ehp.niehs.nih.gov/doi/full/10.1289/EHP9112">
+                    <a href="https://ehp.niehs.nih.gov/doi/full/10.1289/EHP9112">
                         Automated Network Assembly of Mechanistic Literature for
                         Informed Evidence Identification to Support Cancer Risk Assessment
                     </a>
-                    </strong>
                     <i>Environmental Health Perspectives</i>, 2022.
                 </p>
 
                 <p>
                     <span class="badge badge-published">Published</span>
                     Gyori BM and Hoyt CT.
-                    <strong>
-                        <a href='https://joss.theoj.org/papers/10.21105/joss.04136'>
-                            PyBioPAX: biological pathway exchange in Python
-                        </a>
-                    </strong>
+                    <a href='https://joss.theoj.org/papers/10.21105/joss.04136'>
+                        PyBioPAX: biological pathway exchange in Python
+                    </a>
                     <i>Journal of Open Source Software</i>, 2022.
                 </p>
 
@@ -557,11 +554,9 @@
                     Balabin H, <strong>Hoyt CT</strong>, Birkenbihl C,
                     <strong>Gyori BM</strong>, <strong>Bachman JA</strong>,
                     Kodamullil AT, Ploeger PG, Hofmann-Apitius M, Domingo-Fernandez D.
-                    <strong>
-                        <a href='https://doi.org/10.1093/bioinformatics/btac001'>
-                            STonKGs: A Sophisticated Transformer Trained on Biomedical Text and Knowledge Graphs
-                        </a>
-                    </strong>
+                    <a href='https://doi.org/10.1093/bioinformatics/btac001'>
+                        STonKGs: A Sophisticated Transformer Trained on Biomedical Text and Knowledge Graphs
+                    </a>
                     <i>Bioinformatics</i>, 2022.
                 </p>
 
@@ -570,11 +565,9 @@
                     Balabin H, <strong>Hoyt CT</strong>,
                     <strong>Gyori BM</strong>, <strong>Bachman JA</strong>,
                     Kodamullil AT,Hofmann-Apitius M, Domingo-Fernandez D.
-                    <strong>
-                        <a href='http://ceur-ws.org/Vol-3127/paper-13.pdf'>
-                            ProtSTonKGs: A Sophisticated Transformer Trained on Protein Sequences, Text, and Knowledge Graphs
-                        </a>
-                    </strong>
+                    <a href='http://ceur-ws.org/Vol-3127/paper-13.pdf'>
+                        ProtSTonKGs: A Sophisticated Transformer Trained on Protein Sequences, Text, and Knowledge Graphs
+                    </a>
                     <i>SWAT4HCLS</i>, 2022.
                 </p>
 
@@ -587,7 +580,7 @@
                     Moxon, MC Munoz-Torres, D Osumi-Sutherland, JA Overton, B Peters, T Putman, N Queralt-Rosinach, K
                     Shefchek, H Solbrig, A Thessen, T Tudorache, N Vasilevsky, AH Wagner, CJ Mungall
                     <a href='https://doi.org/10.1093/database/baac035'>
-                        <strong>A Simple Standard for Sharing Ontological Mappings (SSSOM)</strong>
+                        A Simple Standard for Sharing Ontological Mappings (SSSOM)
                     </a>
                     <i>Database</i>, 2022.
                 </p>
@@ -597,7 +590,7 @@
                     Stephen Bonner, Ian P Barrett, Cheng Ye, Rowan Swiers, Ola
                     Engkvist, <strong>Hoyt CT</strong>, William L Hamilton
                     <a href="https://doi.org/10.1016/j.ailsci.2022.100036">
-                        <strong>Understanding the Performance of Knowledge Graph Embeddings in Drug Discovery</strong>
+                        Understanding the Performance of Knowledge Graph Embeddings in Drug Discovery
                     </a>
                     <i>Artificial Intelligence in the Life Sciences</i>, 2022.
                 </p>
@@ -607,12 +600,10 @@
                     Doherty LM, Mills CE, Boswell SA, Liu X, <strong>Hoyt CT, Gyori
                     BM</strong>,
                     Buhrlage SJ, Sorger PK.
-                    <strong>
-                        <a href='https://doi.org/10.7554/eLife.72879'>
-                            Integrating multi-omics data reveals function and therapeutic potential of deubiquitinating
-                            enzymes
-                        </a>
-                    </strong>
+                    <a href='https://doi.org/10.7554/eLife.72879'>
+                        Integrating multi-omics data reveals function and therapeutic potential of deubiquitinating
+                        enzymes
+                    </a>
                     <i>eLife</i> 11:e72879, 2022.
                     <br/>Website: <a href="https://labsyspharm.github.io/dubportal/">DUB portal</a>
                 </p>
@@ -625,22 +616,18 @@
                     Vartika Tewari,
                     Robert Ness,
                     Olga Vitek
-                    <strong>
-                        <a href="https://doi.org/10.1093/bioinformatics/btac251">
-                            Do-calculus enables causal reasoning with latent variable models
-                        </a>
-                    </strong>
+                    <a href="https://doi.org/10.1093/bioinformatics/btac251">
+                        Do-calculus enables causal reasoning with latent variable models
+                    </a>
                     <i>Bioinformatics</i>, 2022.
                 </p>
 		    
                 <p>
                     <span class="badge badge-published">Published</span>
                      Valérie de Crécy-lagard, Rocio Amorin de Hegedus, Cecilia Arighi, ..., <strong>Benjamin M Gyori</strong>, ..., Jin Xu
-                    <strong>
-                        <a href="https://doi.org/10.1093/database/baac062">
-                            A roadmap for the functional annotation of protein families: a community perspective
-                        </a>
-                    </strong>
+                    <a href="https://doi.org/10.1093/database/baac062">
+                        A roadmap for the functional annotation of protein families: a community perspective
+                    </a>
                     <i>Database</i>, 2022.
                 </p>
 
@@ -649,11 +636,9 @@
                     Rozemberczki B, <strong>Hoyt CT</strong>, Gogleva A, Grabowski P,
                     <strong>Karis K</strong>, Lamov A, Andriy N, Nilsson S,
                     Ughetto M, Wang Y, Derr T, <strong>Gyori BM</strong>.
-                    <strong>
-                        <a href='https://doi.org/10.1145/3534678.3539023'>
-                            ChemicalX: A Deep Learning Library for Drug Pair Scoring
-                        </a>
-                    </strong>
+                    <a href='https://doi.org/10.1145/3534678.3539023'>
+                        ChemicalX: A Deep Learning Library for Drug Pair Scoring
+                    </a>
                     <i>KDD</i>, 2022.
                 </p>
 
@@ -662,11 +647,9 @@
                     Hungerford J, Chan YS, MacBride J,
                     <strong>Gyori BM</strong>, ...,
                     Reynolds M, Surdeanu M, Bethard S, Sharp R
-                    <strong>
-                        <a href="https://aclanthology.org/2022.hcinlp-1.1/">
-			    Taxonomy Builder: a Data-driven and User-centric Tool for Streamlining Taxonomy Construction
-			</a>
-                    </strong>
+                    <a href="https://aclanthology.org/2022.hcinlp-1.1/">
+			            Taxonomy Builder: a Data-driven and User-centric Tool for Streamlining Taxonomy Construction
+			        </a>
                     <i>NAACL HCI+NLP</i>, 2022.
                 </p>
 
@@ -674,11 +657,9 @@
                     <span class="badge badge-preprint">Preprint</span>
                     Nicole A Vasilevsky, Nicolas A Matentzoglu, ..., <strong>Hoyt
                     CT</strong>, ..., Christopher J Mungall, Ada Hamosh, Melissa A Haendel
-                    <strong>
-                        <a href="https://doi.org/10.1101/2022.04.13.22273750">
-                            MONDO: Unifying diseases for the world, by the world
-                        </a>
-                    </strong>
+                    <a href="https://doi.org/10.1101/2022.04.13.22273750">
+                        MONDO: Unifying diseases for the world, by the world
+                    </a>
                     <i>medRxiv</i>, 2022.
                 </p>
 
@@ -686,23 +667,19 @@
                     <span class="badge badge-preprint">Preprint</span>
                     <strong>Hoyt CT</strong>, Max Berrendorf, Mikhail Gaklin,
                     Volker Tresp, <strong>Gyori BM</strong>.
-                    <strong>
-                        <a href='https://arxiv.org/abs/2203.07544'>
-                            A Unified Framework for Rank-based Evaluation Metrics for
-                            Link Prediction in Knowledge Graphs
-                        </a>
-                    </strong>
+                    <a href='https://arxiv.org/abs/2203.07544'>
+                        A Unified Framework for Rank-based Evaluation Metrics for
+                        Link Prediction in Knowledge Graphs
+                    </a>
                     <i>arXiv</i>, 2022.
                 </p>
 
                 <p>
                     <span class="badge badge-preprint">Preprint</span>
                     Mikhail Gaklin, Max Berrendorf, <strong>Hoyt CT</strong>
-                    <strong>
-                        <a href="https://arxiv.org/abs/2203.01520">
-                            An Open Challenge for Inductive Link Prediction on Knowledge Graphs
-                        </a>
-                    </strong>
+                    <a href="https://arxiv.org/abs/2203.01520">
+                        An Open Challenge for Inductive Link Prediction on Knowledge Graphs
+                    </a>
                     <i>arXiv</i>, 2022.
                 </p>
 
@@ -711,11 +688,9 @@
                     Matentzoglu, N., Goutte-Gattat, D., Tan, S. Z. K., Balhoff, J. P., Carbon, S., Caron, A. R.,
 			Duncan, W. D., Flack, J. E., Haendel, M., Harris, N. L., Hogan, W. R., <strong>Hoyt, C. T.</strong>,
 			Jackson, R. C., Kim, H., Kir, H., Larralde, M., McMurry, J. A., Overton, J. A., Peters, B., … Osumi-Sutherland, D.
-                    <strong>
-                        <a href="https://arxiv.org/abs/2207.02056">
-                            Ontology Development Kit: a toolkit for building, maintaining, and standardising biomedical ontologies
-                        </a>
-                    </strong>
+                    <a href="https://arxiv.org/abs/2207.02056">
+                        Ontology Development Kit: a toolkit for building, maintaining, and standardising biomedical ontologies
+                    </a>
                     <i>arXiv</i>, 2022.
                 </p>
 
@@ -724,11 +699,9 @@
                         <strong>Hoyt, C. T.</strong>, Balk, M., Callahan, T. J., Domingo-Fernandez, D., Haendel, M. A., Hegde, H. B.,
 			Himmelstein, D. S., Karis, K., Kunze, J., Lubiana, T., Matentzoglu, N., McMurry, J., Moxon, S.,
 			Mungall, C. J., Rutz, A., Unni, D. R., Willighagen, E., Winston, D., & <strong>Gyori, B. M.</strong>
-                    <strong>
-                        <a href="https://www.biorxiv.org/content/10.1101/2022.07.08.499378v2">
-                            Unifying the Identification of Biomedical Entities with the Bioregistry
-                        </a>
-                    </strong>
+                    <a href="https://www.biorxiv.org/content/10.1101/2022.07.08.499378v2">
+                        Unifying the Identification of Biomedical Entities with the Bioregistry
+                    </a>
                     <i>bioRxiv</i>, 2022.07.08.499378.
                 </p>
 
@@ -737,9 +710,9 @@
                 <p>
                     <span class="badge badge-published">Published</span>
                     Gyori BM, Bachman JA.
-                    <strong><a href="https://doi.org/10.1016/j.coisb.2021.100362">
+                    <a href="https://doi.org/10.1016/j.coisb.2021.100362">
                         From knowledge to models: automated modeling in systems and synthetic biology.
-                    </a></strong>
+                    </a>
                     <i>Current Opinion in Systems Biology</i>, 2021.
                 </p>
 
@@ -759,11 +732,9 @@
                     <span class="badge badge-published">Published</span>
                     <strong>Gyori BM</strong>, <strong>Bachman JA</strong>,
                     <strong>Kolusheva D</strong>.
-                    <strong>
-                        <a href='https://biocreative.bioinformatics.udel.edu/media/store/files/2021/Track4_pos_5_BC7_submission_195-3.pdf'>
-                            A self-updating causal model of COVID-19 mechanisms built from the scientific literature
-                        </a>
-                    </strong>
+                    <a href='https://biocreative.bioinformatics.udel.edu/media/store/files/2021/Track4_pos_5_BC7_submission_195-3.pdf'>
+                        A self-updating causal model of COVID-19 mechanisms built from the scientific literature
+                    </a>
                     <i>Proceedings of the BioCreative VII Challenge Evaluation Workshop</i>, 2021.
                 </p>
 
@@ -772,11 +743,9 @@
                     Wong J, Franz M, Siper MC, Fong D, Durupinar F, Dallago C, Luna A, Giorgi JM,
                     Rodchenkov I, Babur O, <strong>Bachman JA</strong>, <strong>Gyori BM</strong>,
                     Demir E, Bader G, Sander C.
-                    <strong>
-                        <a href='https://elifesciences.org/articles/68292'>
-                            Author-sourced capture of pathway knowledge in computable form using Biofactoid
-                        </a>
-                    </strong>
+                    <a href='https://elifesciences.org/articles/68292'>
+                        Author-sourced capture of pathway knowledge in computable form using Biofactoid
+                    </a>
                     <i>eLife</i>, 2021 10:e68292.
                 </p>
 
@@ -784,12 +753,10 @@
                     <span class="badge badge-published">Published</span>
                     Ostaszewski M, Niarakis A, ... <strong>Gyori BM</strong>, <strong>Bachman JA</strong>,
                     ..., Baling R, Schneider R.
-                    <strong>
-                        <a href='https://doi.org/10.15252/msb.202110387'>
-                            COVID-19 Disease Map, a computational knowledge repository of SARS-CoV-2 virus-host
-                            interaction mechanisms
-                        </a>
-                    </strong>
+                    <a href='https://doi.org/10.15252/msb.202110387'>
+                        COVID-19 Disease Map, a computational knowledge repository of SARS-CoV-2 virus-host
+                        interaction mechanisms
+                    </a>
                     <i>Molecular Systems Biology</i>, 2021.
                 </p>
 
@@ -798,8 +765,7 @@
                     Stephen Bonner, Ian P Barrett, Cheng Ye, Rowan Swiers, Ola
                     Engkvist, Andreas Bender, <strong>Hoyt CT</strong>, William L Hamilton
                     <a href="https://arxiv.org/abs/2102.10062">
-                        <strong>A Review of Biomedical Datasets Relating to Drug Discovery: A Knowledge Graph
-                            Perspective</strong>
+                        A Review of Biomedical Datasets Relating to Drug Discovery: A Knowledge Graph Perspective
                     </a>
                     <i>arXiv</i>, 2021.
                 </p>
@@ -808,11 +774,9 @@
                     <span class="badge badge-preprint">Preprint</span>
                     Moret N, Liu C, <strong>Gyori BM, Bachman JA, Steppi A</strong>,
                     Taujale R, Huang LC, Hug C, Berginski M, Gomez S, Kannan N, Sorger PK.
-                    <strong>
-                        <a href='https://doi.org/10.1101/2020.04.02.022277'>
-                            Exploring the understudied human kinome for research and therapeutic opportunities
-                        </a>
-                    </strong>
+                    <a href='https://doi.org/10.1101/2020.04.02.022277'>
+                        Exploring the understudied human kinome for research and therapeutic opportunities
+                    </a>
                     <i>bioRxiv</i>, 2021.
                 </p>
 
@@ -835,11 +799,9 @@
                     <strong>Bachman JA</strong>,
                     Tang Z, Lent H, Luo F, Paul M, Bethard S, Barnard K,
                     Morrison C, Surdeanu M.
-                    <strong>
-                        <a href="http://clulab.cs.arizona.edu/papers/NAACL2019_2.pdf">
-                            Eidos, INDRA, & Delphi: From Free Text to Executable Causal Models
-                        </a>
-                    </strong>
+                    <a href="http://clulab.cs.arizona.edu/papers/NAACL2019_2.pdf">
+                        Eidos, INDRA, & Delphi: From Free Text to Executable Causal Models
+                    </a>
                     <i>NAACL</i>, 2019.
                 </p>
 
@@ -848,35 +810,29 @@
                     Hoyt C, Domingo-Fernández D, Aldisi R, Xu L,
                     Kolpeja K, Spalek S, Wollert E, <strong>Bachman J, Gyori BM,
                     Greene P</strong>, Hofmann-Apitius M.
-                    <strong>
-                        <a href="https://doi.org/10.1093/database/baz068">
-                            Re-curation and rational enrichment of knowledge graphs in
-                            Biological Expression Language
-                        </a>
-                    </strong>
+                    <a href="https://doi.org/10.1093/database/baz068">
+                        Re-curation and rational enrichment of knowledge graphs in
+                        Biological Expression Language
+                    </a>
                     <i>Database</i>, 2019.
                 </p>
 
                 <p>
                     <span class="badge badge-published">Published</span>
                     Steppi A, Gyori BM, Bachman JA.
-                    <strong>
-                        <a href='https://joss.theoj.org/papers/10.21105/joss.01708'>
-                            Adeft: Acromine-based Disambiguation of Entities from Text with applications to the
-                            biomedical literature
-                        </a>
-                    </strong>
+                    <a href='https://joss.theoj.org/papers/10.21105/joss.01708'>
+                        Adeft: Acromine-based Disambiguation of Entities from Text with applications to the
+                        biomedical literature
+                    </a>
                     <i>Journal of Open Source Software</i>, 2019.
                 </p>
 
                 <p>
                     <span class="badge badge-preprint">Preprint</span> Bachman JA, Gyori BM Sorger PK.
-                    <strong>
-                        <a href='https://doi.org/10.1101/822668'>
-                            Assembling a corpus of phosphoproteomic annotations using ProtMapper to normalize site
-                            information from databases and text mining
-                        </a>
-                    </strong>
+                    <a href='https://doi.org/10.1101/822668'>
+                        Assembling a corpus of phosphoproteomic annotations using ProtMapper to normalize site
+                        information from databases and text mining
+                    </a>
                     <i>bioRxiv</i>, 2019.
                 </p>
 
@@ -884,10 +840,10 @@
 
                 <p>
                     <span class="badge badge-published">Published</span>
-                    Bachman JA, Gyori BM, Sorger PK. <strong><a
-                        href="https://bmcbioinformatics.biomedcentral.com/articles/10.1186/s12859-018-2211-5">FamPlex: a
-                    resource for entity recognition and relationship resolution of human protein families and complexes
-                    in biomedical text mining.</a></strong>
+                    Bachman JA, Gyori BM, Sorger PK.
+                    <a href="https://bmcbioinformatics.biomedcentral.com/articles/10.1186/s12859-018-2211-5">
+                        FamPlex: a resource for entity recognition and relationship resolution of human protein families and complexes in biomedical text mining.
+                    </a>
                     <i>BMC Bioinformatics</i>, 2018 19(1):248.
                     <br/>Repository: <a href="http://github.com/sorgerlab/famplex">FamPlex</a></p>
 
@@ -900,14 +856,14 @@
                 <h3>Media</h3>
                 <p>
                     <a href="https://labsyspharm.org/gyori-receives-darpa-directors-fellowship/">
-                        <strong>Award announcement</strong>
+                        Award announcement
                     </a>:
                     Ben Gyori <a href="https://labsyspharm.org/gyori-receives-darpa-directors-fellowship/">
                         awarded DARPA Director's Fellowship </a>for 2022-23.
                 </p>
                 <p>
                     <a href="http://www.wired.co.uk/article/darpa-arati-prabhakar-humans-machines">
-                        <strong>WIRED</strong>
+                        WIRED
                     </a>:
                     Our research on human-machine collaboration was featured in WIRED UK, in the article
                     "<a href="http://www.wired.co.uk/article/darpa-arati-prabhakar-humans-machines">
@@ -916,7 +872,7 @@
 
                 <p>
                     <a href="https://www.theguardian.com/technology/audio/2017/mar/10/the-siri-of-the-cell-tech-podcast">
-                        <strong>The Guardian</strong>
+                        The Guardian
                     </a>:
                     Ben Gyori and John Bachman were interviewed by The Guardian in the tech podcast
                     "<a href="https://www.theguardian.com/technology/audio/2017/mar/10/the-siri-of-the-cell-tech-podcast">
@@ -925,7 +881,7 @@
 
                 <p>
                     <a href="https://hms.harvard.edu/magazine/environment/closer-read">
-                        <strong>Harvard Medicine Magazine</strong>
+                        Harvard Medicine Magazine
                     </a>:
                     Ben Gyori and John Bachman were interviewed for an article in Harvard Medicine Magazine. In "<a
                         href="https://hms.harvard.edu/magazine/environment/closer-read">A Closer Read</a>" (see section
@@ -933,7 +889,7 @@
 
                 <p>
                     <a href="https://hms.harvard.edu/news/ais-next-wave">
-                        <strong>Harvard News</strong>
+                        Harvard News
                     </a>:
                     Ben Gyori was interviewed by the Harvard News
                     to talk about how <a href="https://hms.harvard.edu/news/ais-next-wave">
@@ -942,7 +898,8 @@
 
                 <p>
                     <a href="https://www.darpa.mil/news-events/2021-12-06">
-                        <strong>DARPA News & Events</strong></a>
+                        DARPA News & Events
+                    </a>
                     Our work on the ASKE DARPA program is described in <a
                         href="https://www.darpa.mil/news-events/2021-12-06">this</a> article.
                 </p>


### PR DESCRIPTION
This PR removes some of the `<strong>` and `<b>` tags around and in links so the CSS could be changed all together, then makes links blue instead of light grey.

<img width="1320" alt="Screen Shot 2022-08-24 at 13 21 39" src="https://user-images.githubusercontent.com/5069736/186406172-277829e0-0752-4c6c-b01a-7539af91596a.png">
<img width="1320" alt="Screen Shot 2022-08-24 at 13 21 58" src="https://user-images.githubusercontent.com/5069736/186406212-a79f3395-48e0-4e17-a2c3-088c6e78d105.png">

